### PR TITLE
maintainers: Remove Paul and Kris

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,7 +4,5 @@ An alphabetical list of maintainers for the OPI Project by last name:
 
 * [Boris Glimcher](https://github.com/glimchb)
 * [Kyle Mestery](https://github.com/mestery)
-* [Kris Murphy](https://github.com/krmurph)
-* [Paul Pindell](https://github.com/pdp2shirts)
 * [Steven Royer](https://github.com/seroyer)
 * [Mark Sanders](https://github.com/sandersms)


### PR DESCRIPTION
For now, remove Paul and Kris as they are not active in git at the moment.

Elevated git privileges come with responsibility of knowing git, being
comfortable with using it on a daily basis to help the project, and responsibly
merging code. It's a job, in effect, and not a privilege in itself.

I expect once the TSC forms, we may move to a per-repository maintainer
model.

Signed-off-by: Kyle Mestery <mestery@mestery.com>