### PR TITLE
subgroups: update use case group charter

### DIFF
--- a/SUBGROUPS.md
+++ b/SUBGROUPS.md
@@ -132,7 +132,9 @@
 ## Use Case
 
 * Description & Responsibilities
-  * This group is has not started meeting yet.
+  * Create an open channel with the end users and potential deployment partners .
+  * Share the work being done by the groups and get feedback from the deployment partners .
+  * Encourage more deployment partners to contribute , take part and join .
 * Alignment to project goal(s) -- Workgroup leader: Please update this bullet
 * Leader
   * Elad Blatt
@@ -141,7 +143,7 @@
 * Slack Channel
   * [use-case-subgroup](https://opi-project.slack.com/archives/C038BL2KFFU)
 * Status
-  * Forming
+  * Active
 
 ## Events and Outreach
 


### PR DESCRIPTION
As we move forward, use case group is changing it's goals
and responsibilities and focusing on creating a

  channel with the end users and potential deployment partners

Signed-off-by: Elad <Eladb@silicom.co.il>
Signed-off-by: Boris Glimcher <Boris.Glimcher@emc.com>
