### PR TITLE
maintainers: Add policies around maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -63,10 +63,17 @@ The process to grant someone the maintainer role is simple:
 
 ### Revoking Maintainer Rights
 
-When a maintainer acts in a way which is either detrimental to the OPI project,
-it raises a situation which needs to be handled quickly to ensure the long-term
-success and stability of the project. It is possible the maintainer in question
-will have their maintainer rights removed. The process for this is as follows:
+There are times when a maintainer will be removed in a peaceful way. For
+example, the maintainers may decide that someone should not have merge rights
+due to their lack of git knowledge. In this case, the maintainers can talk
+to this indvidual and work to revoke their maintainer access.
+
+However, there are times when a maintainer may need to be forcefully
+removeed. When a maintainer acts in a way which is either detrimental to the
+OPI project, it raises a situation which needs to be handled quickly to ensure
+the long-term success and stability of the project. It is possible the
+maintainer in question will have their maintainer rights removed. The process
+for this is as follows:
 
 * Discuss with the individual privately about the concerns. Use email for this,
   sticking to the facts, and try to reach a resolution on the individuals.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -54,12 +54,12 @@ The process to grant someone the maintainer role is simple:
   rights.
 * After discussion has ended, existing maintainers will vote on approving the
   new maintainer.
-* To recieve maintainership, the candidate must receive a majority of yes votes
+* To receive maintainership, the candidate must receive a majority of yes votes
   and zero no votes.
 * One final discussion with the candidate happens to ensure the candidate is
   ready to accept the maintainer role.
 * If successful, the candidate is added to the appropriate GitHub group to
-  gain maintainer access.
+  gain maintainer access, as well as the maintainers Slack channel.
 
 ### Revoking Maintainer Rights
 
@@ -69,16 +69,16 @@ due to their lack of git knowledge. In this case, the maintainers can talk
 to this indvidual and work to revoke their maintainer access.
 
 However, there are times when a maintainer may need to be forcefully
-removeed. When a maintainer acts in a way which is either detrimental to the
-OPI project, it raises a situation which needs to be handled quickly to ensure
-the long-term success and stability of the project. It is possible the
+removed. When a maintainer acts in a way which is detrimental to the OPI
+project, it raises a situation which needs to be handled quickly to ensure the
+long-term success and stability of the project. It is possible the
 maintainer in question will have their maintainer rights removed. The process
 for this is as follows:
 
 * Discuss with the individual privately about the concerns. Use email for this,
   sticking to the facts, and try to reach a resolution on the individuals.
   behavior. Ensure the individual understands their behavior needs to change.
-* Send an email discussing the individuals behavior to the maintainer mailing
+* Send an email discussing the individual's behavior to the maintainer mailing
   list. Work to resolve the issue in this forum.
 * If necessary, start a thread with maintainers except the individual in
   question regarding revoking the individuals maintainer rights.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,5 +1,97 @@
 # Maintainers
 
+OPI maintainers do the work of keeping the project running.
+
+Maintainers do the following things in support of OPI projects:
+
+* Writing code for new features
+* Writing code to fix bugs
+* Opening bug reports
+* Triaging bug reports
+* Closing bug reports
+* Reviewing pull requests
+* Merging pull requests from contributors
+* Resolving conflict found on pull request reviews
+* Proactively dealing with technical debt
+* Supporting documentation
+* Guiding the projects strategic direction
+
+In other words, maintainers are involved in day-to-day operations of the
+project.
+
+## OPI Maintainer Prerequisites
+
+You should understand the [contributing](https://github.com/opiproject/opi/blob/main/CONTRIBUTING.md)
+guidelines if you want to become a maintainer.
+
+## OPI Maintainer Grant/Revocation Policy
+
+An OPI maintainer is a participant in OPI who has the ability to merge pull
+requests directly into main branch on OPI repositories. This ability grants
+the maintainers the ability to affect the progress of the OPI project in a way
+non-maintainers cannot. Being an OPI maintainer represents a significant level
+of trust to the broader project. Maintainer rights are not granted lightly,
+and will be reviewed as necessary to ensure that trust has not been violated.
+
+### Granting Maintainer Rights
+
+Granting maintainer rights will be considered when a candidate has demonstrated
+the following in their interation with the project:
+
+* Contribution of significant new features to OPI.
+  * Submissions are free of obvious defects.
+  * Submissions do not require many revisions.
+* Consistent and meaningful code reviews of other people's pull requests.
+* Helping others in the community via channels such as the mailing list,
+  GitHub. Issues and PRs, and the Slack channels
+* The individual should have plans for sustained contribution to the project.
+
+The process to grant someone the maintainer role is simple:
+
+* An existing maintainer nominates someone by sending a message to the
+  maintainers slack channel.
+* Existing maintainers discuss the idea of giving the candidate maintainer
+  rights.
+* After discussion has ended, existing maintainers will vote on approving the
+  new maintainer.
+* To recieve maintainership, the candidate must receive a majority of yes votes
+  and zero no votes.
+* One final discussion with the candidate happens to ensure the candidate is
+  ready to accept the maintainer role.
+* If successful, the candidate is added to the appropriate GitHub group to
+  gain maintainer access.
+
+### Revoking Maintainer Rights
+
+When a maintainer acts in a way which is either detrimental to the OPI project,
+it raises a situation which needs to be handled quickly to ensure the long-term
+success and stability of the project. It is possible the maintainer in question
+will have their maintainer rights removed. The process for this is as follows:
+
+* Discuss with the individual privately about the concerns. Use email for this,
+  sticking to the facts, and try to reach a resolution on the individuals.
+  behavior. Ensure the individual understands their behavior needs to change.
+* Send an email discussing the individuals behavior to the maintainer mailing
+  list. Work to resolve the issue in this forum.
+* If necessary, start a thread with maintainers except the individual in
+  question regarding revoking the individuals maintainer rights.
+* Each maintainer may vote yes, no, or abstain. Not voting is equivalent to
+  abstain.
+* After all votes are collected, to remove the maintainer, the vote must be
+  a 2/3 yes vote in favor of removal.
+* Any no votes should document their reasons for not voting to remove the
+  persons maintainership.
+* The person proposing revoking maintainer rights sends email to the list
+  announcing the results.
+* If the vote to remove is successful, the candidate will be removed from the
+  GitHub group which has merge rights.
+* Ideally, the revoked committer peacefully leaves the community. If this is
+  not the case, the maintainers have documented the reason for removal above,
+  and this can be shared with the broader community in support of their
+  decision.
+
+## List of Maintainers
+
 An alphabetical list of maintainers for the OPI Project by last name:
 
 * [Boris Glimcher](https://github.com/glimchb)


### PR DESCRIPTION
This adds policies around what maintainers do, how they are added and
removed, and how they generally work.

Signed-off-by: Kyle Mestery <mestery@mestery.com>