### PR TITLE
maintainers: Update maintainer policy

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -24,6 +24,37 @@ project.
 You should understand the [contributing](https://github.com/opiproject/opi/blob/main/CONTRIBUTING.md)
 guidelines if you want to become a maintainer.
 
+## OPI Maintainer Groups
+
+We recognize the need to have a few different groups with merge rights. For
+example, the TSC is likely to want to merge to the main
+[OPI](https://github.com/opiproject/opi) repository around policies and
+procedures, but those same members may not have merge rights to other
+repositories with code in them.
+
+With the above in mind, the following three groups of maintainers exist inside
+of OPI:
+
+| Maintainer Group | Repositories Allowed To Merge                  |
+| ---------------- | ---------------------------------------------- |
+| opi-tsc          | `https://github.com/opiproject/opi`            |
+| opi-outreach     | `https://github.com/opiproject/opiproject.org` |
+| opi-maintainers  | All OPI repositories                           |
+
+This allows the TSC to help merge *policy* based things in the OPI
+repository. It also allows the Outreach group to merge website updates. It will
+also allow existing code reviewers to continue to merge *code* in the other
+repositories. And existing maintainers can still review and merge things in the
+opiproject.org and opi repositories as well, which will help with velocity in
+those repositories.
+
+Please note that even TSC and outreach members need to have a basic
+understanding of git to have merge rights.
+
+Finally, note that having merge rights to *any* OPI repo is a job and not a
+privilege. If people are not reviewing PRs in a meaningful way, they stand to
+lose merge rights, per the policy found below.
+
 ## OPI Maintainer Grant/Revocation Policy
 
 An OPI maintainer is a participant in OPI who has the ability to merge pull


### PR DESCRIPTION
Per discussion on the mailing list [1], this commit updates the maintaienr policy to propose adding two new groups with merge rights. We will end up with 3 different groups with merge rights if this change is approved by the OPI TSC:

* An `opi-tsc` group which can merge into the main opi repository [2]
* An `opi-outreach` group which can merge into the website repository [3]
* The existing `opi-maintainers` group which can merge into all OPI repositories.

[1] https://lists.opiproject.org/g/tsc/message/36
[2] https://github.com/opiproject/opi
[3] https://github.com/opiproject/opiproject.org

Signed-off-by: Kyle Mestery <mestery@mestery.com>