### PR TITLE
Add spending_guidelines.md

### DIFF
--- a/Policies/spending_guidelines.md
+++ b/Policies/spending_guidelines.md
@@ -1,0 +1,84 @@
+# OPI Lab Budget Guidelines
+
+This document provides guidance for using OPI funds to acquire lab
+equipment.  We describe both "appropriate" and "inappropriate" use of
+equipment funds and include examples of each.  Generally, commonly
+used lab equipment generally available in the market are appropriate.
+Pre-production equipment or equipment that does not service the
+goals of the OPI lab are inappropriate.
+
+
+## Appropriate
+
+### General purpose servers
+
+- 1U, 2U, 3U, 4U rack servers with PCIE 3.0/4.0/5.0 slots
+- Pedestal servers
+
+### Server peripherals
+
+- Hard drives
+- RAM
+- NIC cards
+
+### Test equipment
+
+- Traffic generators
+
+### Cables
+
+- Optical cables
+- Transceivers
+- DAC cables
+
+### Storage servers
+
+### Switches
+
+- Top of Rack Layer 2/3 switches
+- Layer 1 switches
+- Programmable switches
+
+### PDUs
+
+- PDUs
+- C13/C14/C15 power cables
+
+### KVMs
+
+- KVMs
+- Dongles
+
+
+### Terminal servers
+
+### DPUs/IPUs
+
+- Generally available DPUs
+- Generally available IPUs
+
+### Software
+
+- OS licenses
+- Software required to enable hardware
+
+### Hosting services (University of New Hamshire Interoperatability Lab)
+
+- Rack space
+- Electricity
+- HVAC
+- Services (lab tech to change cables)
+
+## Inappropriate
+
+### Pre-production equipment
+
+- Pre-production DPUs/IPUs
+- Pre-production servers
+- Pre-production switches
+
+### Incompatible with goals of OPI Lab
+
+- Travel
+- Meal
+- Entertainment

--- a/Policies/spending_guidelines.md
+++ b/Policies/spending_guidelines.md
@@ -7,7 +7,6 @@ used lab equipment generally available in the market are appropriate.
 Pre-production equipment or equipment that does not service the
 goals of the OPI lab are inappropriate.
 
-
 ## Appropriate
 
 ### General purpose servers
@@ -48,7 +47,6 @@ goals of the OPI lab are inappropriate.
 
 - KVMs
 - Dongles
-
 
 ### Terminal servers
 


### PR DESCRIPTION
Add spending guideline document approved by the TSC.  Same as original except 'Transportation' replaced by 'Travel'. This change makes the language congruous with standard 'travel, meal, entertainment' expense type.

Signed-off-by: Keith Kong <kkongusa@gmail.com>