### PR TITLE
Remove Kyle as maintainer

### DIFF
--- a/Policies/MAINTAINERS.md
+++ b/Policies/MAINTAINERS.md
@@ -135,3 +135,7 @@ An alphabetical list of maintainers for the OPI Project by last name:
 * [Boris Glimcher](https://github.com/glimchb)
 * [Steven Royer](https://github.com/seroyer)
 * [Mark Sanders](https://github.com/sandersms)
+
+We also maintain a list of Emeritus Maintainers:
+
+* [Kyle Mestery](https://github.com/mestery)

--- a/Policies/MAINTAINERS.md
+++ b/Policies/MAINTAINERS.md
@@ -133,6 +133,5 @@ for this is as follows:
 An alphabetical list of maintainers for the OPI Project by last name:
 
 * [Boris Glimcher](https://github.com/glimchb)
-* [Kyle Mestery](https://github.com/mestery)
 * [Steven Royer](https://github.com/seroyer)
 * [Mark Sanders](https://github.com/sandersms)


### PR DESCRIPTION
End of an era.

Signed-off-by: Kyle Mestery <mestery@mestery.com>